### PR TITLE
[DRAFT]: Adds proposal skeleton

### DIFF
--- a/clearml_serving/__main__.py
+++ b/clearml_serving/__main__.py
@@ -263,6 +263,7 @@ def func_model_auto_update_add(args):
             output_type=args.output_type,
             output_name=args.output_name,
             auxiliary_cfg=aux_config,
+            triton_config_file=args.triton_config_file
         ),
         preprocess_code=args.preprocess
     ):
@@ -302,6 +303,7 @@ def func_model_endpoint_add(args):
             output_type=args.output_type,
             output_name=args.output_name,
             auxiliary_cfg=aux_config,
+            triton_config_file=args.triton_config_file
         ),
         preprocess_code=args.preprocess,
         model_name=args.name,

--- a/clearml_serving/engines/triton/triton_helper.py
+++ b/clearml_serving/engines/triton/triton_helper.py
@@ -5,6 +5,7 @@ import subprocess
 from argparse import ArgumentParser
 from time import time
 from typing import Optional
+import shutil
 
 import numpy as np
 from clearml import Task, Logger, InputModel
@@ -319,7 +320,16 @@ class TritonHelper(object):
                 config[k] = _convert_lists(v)
 
             return config
+        
+        def validate_config_file(config):
+            pass
 
+        if endpoint.triton_config_file: # if passed the config file directly
+            if not validate_config_file(endpoint.triton_config_file):
+                raise AssertionError("Invalid config file")
+            shutil.copyfile(endpoint.triton_config_file, target_pbtxt_file)
+            return True
+        
         final_config_pbtxt = ""
         config_dict = dict()
 
@@ -390,6 +400,8 @@ class TritonHelper(object):
         with open(target_pbtxt_file, "w") as config_file:
             config_file.write(final_config_pbtxt)
 
+        print("final_config_pbtxt", final_config_pbtxt)
+        print("target_pbtxt_file", target_pbtxt_file)
         return True
 
     @staticmethod

--- a/clearml_serving/serving/endpoints.py
+++ b/clearml_serving/serving/endpoints.py
@@ -59,6 +59,7 @@ class ModelMonitoring(BaseStruct):
     preprocess_artifact = attrib(
         type=str, default=None)  # optional artifact name storing the model preprocessing code
     auxiliary_cfg = attrib(type=dict, default=None)  # Auxiliary configuration (e.g. triton conf), Union[str, dict]
+    triton_config_file = attrib(type=str, default=None) # Triton configuration file path
 
 
 @attrs
@@ -76,6 +77,7 @@ class ModelEndpoint(BaseStruct):
     output_type = attrib(type=list, default=None, validator=_matrix_type_validator, converter=_list_type_convertor)
     output_name = attrib(type=list, default=None, converter=_list_type_convertor)  # optional, output layer names
     auxiliary_cfg = attrib(type=dict, default=None)  # Optional: Auxiliary configuration (e.g. triton conf), [str, dict]
+    triton_config_file = attrib(type=str, default=None) # Triton configuration file path
 
 
 @attrs


### PR DESCRIPTION
This PR is a proposal to allow the Triton file config to be passed directly, allowing more customized configurations without having to format it in the way `auxiliary_cfg` expeccts. 

